### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/mgtestintegrations/2b044b19-3d1d-4444-bbe1-8ae7819e12cd/0ba393e1-0723-4cf7-bccc-6491bfa930eb/_apis/work/boardbadge/1642dbc5-7a20-4f2c-b723-b2f4ba04c282)](https://dev.azure.com/mgtestintegrations/2b044b19-3d1d-4444-bbe1-8ae7819e12cd/_boards/board/t/0ba393e1-0723-4cf7-bccc-6491bfa930eb/Microsoft.RequirementCategory)
 # repoa


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.